### PR TITLE
add profile and events endpoints with auth-based access

### DIFF
--- a/src/main/java/ru/kpfu/itis/webapp/controller/EventController.java
+++ b/src/main/java/ru/kpfu/itis/webapp/controller/EventController.java
@@ -2,11 +2,14 @@ package ru.kpfu.itis.webapp.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import ru.kpfu.itis.webapp.dto.EventFullDto;
 import ru.kpfu.itis.webapp.dto.EventShortDto;
+import ru.kpfu.itis.webapp.security.details.AccountUserDetails;
 import ru.kpfu.itis.webapp.service.EventService;
 
 import java.util.List;
@@ -26,6 +29,24 @@ public class EventController {
         return eventService.getFullEventById(eventId)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/my-events")
+    @PreAuthorize("hasAnyRole('ORGANIZER', 'STUDENT')")
+    public ResponseEntity<List<EventShortDto>> getSubscribedEvents(
+            @AuthenticationPrincipal AccountUserDetails userDetails
+    ) {
+        Long userId = userDetails.getAccount().getId();
+        return ResponseEntity.ok(eventService.getSubscribedEvents(userId));
+    }
+
+    @GetMapping("/organizer/events")
+    @PreAuthorize("hasRole('ORGANIZER')")
+    public ResponseEntity<List<EventShortDto>> getOrganizerEvents(
+            @AuthenticationPrincipal AccountUserDetails userDetails
+    ) {
+        Long organizerId = userDetails.getAccount().getId();
+        return ResponseEntity.ok(eventService.getEventsByOrganizer(organizerId));
     }
 
 }

--- a/src/main/java/ru/kpfu/itis/webapp/controller/ProfileController.java
+++ b/src/main/java/ru/kpfu/itis/webapp/controller/ProfileController.java
@@ -1,0 +1,25 @@
+package ru.kpfu.itis.webapp.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import ru.kpfu.itis.webapp.dto.ProfileDto;
+import ru.kpfu.itis.webapp.entity.Account;
+import ru.kpfu.itis.webapp.security.details.AccountUserDetails;
+
+@Controller
+public class ProfileController {
+
+    @GetMapping("/api/profile")
+    public ResponseEntity<ProfileDto> getProfile(@AuthenticationPrincipal AccountUserDetails userDetails) {
+        Account account = userDetails.getAccount();
+        ProfileDto profileDto = new ProfileDto();
+        profileDto.setId(account.getId());
+        profileDto.setEmail(account.getEmail());
+        profileDto.setRole(account.getRole().name());
+        profileDto.setPhotoUrl(account.getPhotoUrl());
+        return ResponseEntity.ok(profileDto);
+    }
+
+}

--- a/src/main/java/ru/kpfu/itis/webapp/dto/ProfileDto.java
+++ b/src/main/java/ru/kpfu/itis/webapp/dto/ProfileDto.java
@@ -1,0 +1,11 @@
+package ru.kpfu.itis.webapp.dto;
+
+import lombok.Data;
+
+@Data
+public class ProfileDto {
+    private Long id;
+    private String email;
+    private String role;
+    private String photoUrl;
+}

--- a/src/main/java/ru/kpfu/itis/webapp/entity/Account.java
+++ b/src/main/java/ru/kpfu/itis/webapp/entity/Account.java
@@ -22,9 +22,13 @@ public class Account {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private AccountRole role;  // STUDENT, ORGANIZER или GUEST
+    private AccountRole role;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private AccountState state;  // CONFIRMED, NOT_CONFIRMED и т.д.
+    private AccountState state;
+
+    @Column
+    private String photoUrl;
+
 }

--- a/src/main/java/ru/kpfu/itis/webapp/entity/Participation.java
+++ b/src/main/java/ru/kpfu/itis/webapp/entity/Participation.java
@@ -1,0 +1,19 @@
+package ru.kpfu.itis.webapp.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+public class Participation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Account user;
+
+    @ManyToOne
+    private Event event;
+}

--- a/src/main/java/ru/kpfu/itis/webapp/repository/EventRepository.java
+++ b/src/main/java/ru/kpfu/itis/webapp/repository/EventRepository.java
@@ -3,4 +3,8 @@ package ru.kpfu.itis.webapp.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.kpfu.itis.webapp.entity.Event;
 
-public interface EventRepository extends JpaRepository<Event, Long> {}
+import java.util.List;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+    List<Event> findByOrganizerId(Long organizerId);
+}

--- a/src/main/java/ru/kpfu/itis/webapp/repository/ParticipationRepository.java
+++ b/src/main/java/ru/kpfu/itis/webapp/repository/ParticipationRepository.java
@@ -1,0 +1,10 @@
+package ru.kpfu.itis.webapp.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.kpfu.itis.webapp.entity.Participation;
+
+import java.util.List;
+
+public interface ParticipationRepository extends JpaRepository<Participation, Long> {
+    List<Participation> findByUserId(Long userId);
+}

--- a/src/main/java/ru/kpfu/itis/webapp/security/SecurityConfig.java
+++ b/src/main/java/ru/kpfu/itis/webapp/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/organizer/**").hasRole("ORGANIZER")
                         .requestMatchers("/student/**").hasRole("STUDENT")
-                        .requestMatchers("/profile/**").authenticated()
+                        .requestMatchers("/profile/**", "/my-events", "/organizer/events").authenticated()
                         .anyRequest().permitAll()
                 )
                 .formLogin(form -> form

--- a/src/main/java/ru/kpfu/itis/webapp/security/details/AccountUserDetails.java
+++ b/src/main/java/ru/kpfu/itis/webapp/security/details/AccountUserDetails.java
@@ -1,5 +1,6 @@
 package ru.kpfu.itis.webapp.security.details;
 
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,6 +9,7 @@ import ru.kpfu.itis.webapp.entity.AccountState;
 import java.util.Collection;
 import java.util.Collections;
 
+@Getter
 public class AccountUserDetails implements UserDetails {
     private final Account account;
 
@@ -49,4 +51,5 @@ public class AccountUserDetails implements UserDetails {
     public boolean isEnabled() {
         return account.getState() == AccountState.CONFIRMED;
     }
+
 }

--- a/src/main/java/ru/kpfu/itis/webapp/service/EventService.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/EventService.java
@@ -5,7 +5,9 @@ import org.springframework.stereotype.Service;
 import ru.kpfu.itis.webapp.dto.EventFullDto;
 import ru.kpfu.itis.webapp.dto.EventShortDto;
 import ru.kpfu.itis.webapp.entity.Event;
+import ru.kpfu.itis.webapp.entity.Participation;
 import ru.kpfu.itis.webapp.repository.EventRepository;
+import ru.kpfu.itis.webapp.repository.ParticipationRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +17,7 @@ import java.util.Optional;
 public class EventService {
 
     private final EventRepository eventRepository;
+    private final ParticipationRepository participationRepository;
 
     public List<EventShortDto> getAllShortEvents() {
         return eventRepository.findAll().stream()
@@ -47,6 +50,19 @@ public class EventService {
                 event.getOrganizerId(),
                 event.getCategory()
         );
+    }
+
+    public List<EventShortDto> getEventsByOrganizer(Long organizerId) {
+        return eventRepository.findByOrganizerId(organizerId).stream()
+                .map(this::convertToShortDto)
+                .toList();
+    }
+
+    public List<EventShortDto> getSubscribedEvents(Long userId) {
+        return participationRepository.findByUserId(userId).stream()
+                .map(Participation::getEvent)
+                .map(this::convertToShortDto)
+                .toList();
     }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -53,19 +53,37 @@ SELECT 'Фестиваль уличного искусства', 'Граффит
     WHERE NOT EXISTS (SELECT 1 FROM event WHERE title = 'Фестиваль уличного искусства');
 
 
-INSERT INTO account (email, password, role, state)
-SELECT 'student@example.com', '$2a$10$Jmzm0cm58VLm0yo/dYdcKu6Gqm6UJzZqeBieIH/DkGgZ3jcAQHw6a', 'STUDENT', 'CONFIRMED'
+INSERT INTO account (email, password, role, state, photo_url)
+SELECT 'student@example.com', '$2a$10$Jmzm0cm58VLm0yo/dYdcKu6Gqm6UJzZqeBieIH/DkGgZ3jcAQHw6a', 'STUDENT', 'CONFIRMED', 'http://localhost:9001/browser/event-horizon/ProfilePhoto%2Favatar1.png'
     WHERE NOT EXISTS (SELECT 1 FROM account WHERE email = 'student@example.com');
 
-INSERT INTO account (email, password, role, state)
-SELECT 'student1@example.com', '$2a$10$Jmzm0cm58VLm0yo/dYdcKu6Gqm6UJzZqeBieIH/DkGgZ3jcAQHw6a', 'STUDENT', 'CONFIRMED'
-    WHERE NOT EXISTS (SELECT 1 FROM account WHERE email = 'student1@example.com');
+INSERT INTO account (email, password, role, state, photo_url)
+SELECT 'not_confirmed@example.com', '$2a$10$Jmzm0cm58VLm0yo/dYdcKu6Gqm6UJzZqeBieIH/DkGgZ3jcAQHw6a', 'STUDENT', 'NOT_CONFIRMED', 'http://localhost:9001/browser/event-horizon/ProfilePhoto%2Favatar2.png'
+    WHERE NOT EXISTS (SELECT 1 FROM account WHERE email = 'not_confirmed@example.com');
 
 
-INSERT INTO account (email, password, role, state)
-SELECT 'organizer@example.com', '$2a$10$N9qo8uLOickgx2ZMRZoMy.MH/qj6W1mA6bYSUBBtFQ7Ug2QbSbaRe', 'ORGANIZER', 'CONFIRMED'
+INSERT INTO account (email, password, role, state, photo_url)
+SELECT 'organizer@example.com', '$2a$10$Jmzm0cm58VLm0yo/dYdcKu6Gqm6UJzZqeBieIH/DkGgZ3jcAQHw6a', 'ORGANIZER', 'CONFIRMED', 'http://localhost:9001/browser/event-horizon/ProfilePhoto%2Favatar3.png'
     WHERE NOT EXISTS (SELECT 1 FROM account WHERE email = 'organizer@example.com');
 
-INSERT INTO account (email, password, role, state)
-SELECT 'banned@example.com', '$2a$10$N9qo8uLOickgx2ZMRZoMy.MH/qj6W1mA6bYSUBBtFQ7Ug2QbSbaRe', 'GUEST', 'BANNED'
+INSERT INTO account (email, password, role, state, photo_url)
+SELECT 'banned@example.com', '$2a$10$N9qo8uLOickgx2ZMRZoMy.MH/qj6W1mA6bYSUBBtFQ7Ug2QbSbaRe', 'GUEST', 'BANNED', 'http://localhost:9001/browser/event-horizon/ProfilePhoto%2Favatar1.png'
     WHERE NOT EXISTS (SELECT 1 FROM account WHERE email = 'banned@example.com');
+
+INSERT INTO participation (event_id, user_id)
+SELECT e.id, a.id
+FROM event e, account a
+WHERE e.title = 'Научная конференция' AND a.email = 'student@example.com'
+  AND NOT EXISTS (SELECT 1 FROM participation WHERE event_id = e.id AND user_id = a.id);
+
+INSERT INTO participation (event_id, user_id)
+SELECT e.id, a.id
+FROM event e, account a
+WHERE e.title = 'Футбольный матч' AND a.email = 'student@example.com'
+  AND NOT EXISTS (SELECT 1 FROM participation WHERE event_id = e.id AND user_id = a.id);
+
+INSERT INTO participation (event_id, user_id)
+SELECT e.id, a.id
+FROM event e, account a
+WHERE e.title = 'Выставка современного искусства' AND a.email = 'organizer@example.com'
+  AND NOT EXISTS (SELECT 1 FROM participation WHERE event_id = e.id AND user_id = a.id);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,7 +3,8 @@ CREATE TABLE IF NOT EXISTS account (
     email VARCHAR(255) UNIQUE NOT NULL,
     password VARCHAR(255) NOT NULL,
     role VARCHAR(20) NOT NULL CHECK (role IN ('STUDENT', 'ORGANIZER', 'GUEST')),
-    state VARCHAR(20) NOT NULL CHECK (state IN ('CONFIRMED', 'NOT_CONFIRMED', 'DELETED', 'BANNED'))
+    state VARCHAR(20) NOT NULL CHECK (state IN ('CONFIRMED', 'NOT_CONFIRMED', 'DELETED', 'BANNED')),
+    photo_url VARCHAR(255)
 );
 
 CREATE TABLE IF NOT EXISTS event (
@@ -15,6 +16,13 @@ CREATE TABLE IF NOT EXISTS event (
     participant_limit INTEGER,
     organizer_id BIGINT,
     category VARCHAR(50)
+);
+
+CREATE TABLE IF NOT EXISTS participation
+(
+    id BIGSERIAL PRIMARY KEY,
+    event_id INTEGER REFERENCES event(id) NOT NULL,
+    user_id INTEGER REFERENCES account(id) NOT NULL
 );
 
 create table if not exists persistent_logins


### PR DESCRIPTION
## Что сделано:
- Реализованы эндпоинты:
  - `GET /api/profile` — возвращает данные профиля (включая фото) текущего пользователя.
  - `GET /my-events` — возвращает события, на которые подписан пользователь (доступно для STUDENT и ORGANIZER).
  - `GET /organizer/events` — возвращает события, созданные текущим организатором (доступно только ORGANIZER).