### PR TITLE
add event filtering by title in GET /events endpoint

### DIFF
--- a/src/main/java/ru/kpfu/itis/webapp/controller/EventController.java
+++ b/src/main/java/ru/kpfu/itis/webapp/controller/EventController.java
@@ -8,6 +8,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import ru.kpfu.itis.webapp.dto.EventCreationRequest;
+import ru.kpfu.itis.webapp.dto.EventFilter;
 import ru.kpfu.itis.webapp.dto.EventFullDto;
 import ru.kpfu.itis.webapp.dto.EventShortDto;
 import ru.kpfu.itis.webapp.security.details.AccountUserDetails;
@@ -21,8 +22,8 @@ public class EventController {
     private final EventService eventService;
 
     @GetMapping("/event")
-    public ResponseEntity<List<EventShortDto>> getAllEvents() {
-        return ResponseEntity.ok(eventService.getAllShortEvents());
+    public ResponseEntity<List<EventShortDto>> getAllEvents(@ModelAttribute EventFilter filter) {
+        return ResponseEntity.ok(eventService.getAllShortEvents(filter));
     }
 
     @PostMapping("/event")

--- a/src/main/java/ru/kpfu/itis/webapp/dto/EventFilter.java
+++ b/src/main/java/ru/kpfu/itis/webapp/dto/EventFilter.java
@@ -1,0 +1,10 @@
+package ru.kpfu.itis.webapp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EventFilter {
+    private String title;
+}

--- a/src/main/java/ru/kpfu/itis/webapp/repository/EventRepository.java
+++ b/src/main/java/ru/kpfu/itis/webapp/repository/EventRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByOrganizerId(Long organizerId);
     long countByOrganizerId(Long organizerId);
+    List<Event> findByTitleContainingIgnoreCase(String title);
 }

--- a/src/main/java/ru/kpfu/itis/webapp/service/EventService.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/EventService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import ru.kpfu.itis.webapp.dto.EventCreationRequest;
+import ru.kpfu.itis.webapp.dto.EventFilter;
 import ru.kpfu.itis.webapp.dto.EventFullDto;
 import ru.kpfu.itis.webapp.dto.EventShortDto;
 import ru.kpfu.itis.webapp.entity.Account;
@@ -35,8 +36,14 @@ public class EventService {
     @Value("${minio.bucket}")
     private String bucketName;
 
-    public List<EventShortDto> getAllShortEvents() {
-        return eventRepository.findAll().stream()
+    public List<EventShortDto> getAllShortEvents(EventFilter filter) {
+        List<Event> events;
+        if (filter.getTitle() != null && !filter.getTitle().isEmpty()) {
+            events = eventRepository.findByTitleContainingIgnoreCase(filter.getTitle());
+        } else {
+            events = eventRepository.findAll();
+        }
+        return events.stream()
                 .map(this::convertToShortDto)
                 .toList();
     }


### PR DESCRIPTION
Добавил возможность фильтрации событий по части названия через параметр title в GET-запросе /api/events. Фильтрация выполняется без учета регистра (например, запрос ?title=sci найдет события с названием "Science Fair").