### PR TITLE
implement event deletion with resource cleanup

### DIFF
--- a/src/main/java/ru/kpfu/itis/webapp/controller/EventController.java
+++ b/src/main/java/ru/kpfu/itis/webapp/controller/EventController.java
@@ -59,6 +59,18 @@ public class EventController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @Operation(summary = "Удалить событие", description = "Доступно организатору события")
+    @DeleteMapping("/{eventId}")
+    @PreAuthorize("hasRole('ORGANIZER')")
+    public ResponseEntity<Void> deleteEvent(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal AccountUserDetails userDetails
+    ) {
+        Long organizerId = userDetails.getAccount().getId();
+        eventService.deleteEvent(eventId, organizerId);
+        return ResponseEntity.noContent().build();
+    }
+
     @Operation(summary = "Подписаться на событие", description = "Доступно студентам и организаторам")
     @PostMapping("/{eventId}/subscribe")
     @PreAuthorize("hasAnyRole('STUDENT', 'ORGANIZER')")

--- a/src/main/java/ru/kpfu/itis/webapp/repository/ParticipationRepository.java
+++ b/src/main/java/ru/kpfu/itis/webapp/repository/ParticipationRepository.java
@@ -11,5 +11,5 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     boolean existsByUserIdAndEventId(Long userId, Long eventId);
     long countByEventId(Long eventId);
     Optional<Participation> findByUserIdAndEventId(Long userId, Long eventId);
-
+    List<Participation> findByEventId(Long eventId);
 }

--- a/src/main/java/ru/kpfu/itis/webapp/service/EventService.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/EventService.java
@@ -7,6 +7,7 @@ import com.google.zxing.common.BitMatrix;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import ru.kpfu.itis.webapp.dto.EventCreationRequest;
@@ -163,5 +164,30 @@ public class EventService {
         } catch (Exception e) {
             throw new ServiceException("Ошибка генерации QR-кода");
         }
+    }
+
+    @Transactional
+    public void deleteEvent(Long eventId, Long organizerId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new DataNotFoundException("Event not found"));
+
+        if (!event.getOrganizerId().equals(organizerId)) {
+            throw new AccessDeniedException("Only event organizer can delete it");
+        }
+
+        List<Participation> participations = participationRepository.findByEventId(eventId);
+
+        for (Participation participation : participations) {
+            if (participation.getQrCodeUid() != null) {
+                fileService.deleteFile(participation.getQrCodeUid());
+            }
+            participationRepository.delete(participation);
+        }
+
+        if (event.getImageUid() != null) {
+            fileService.deleteFile(event.getImageUid());
+        }
+
+        eventRepository.delete(event);
     }
 }

--- a/src/main/java/ru/kpfu/itis/webapp/service/FileService.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/FileService.java
@@ -6,4 +6,5 @@ public interface FileService {
     String uploadFile(MultipartFile multipartFile, String objectName) throws Exception;
     String getBaseUrl();
     boolean fileExists(String objectName);
+    void deleteFile(String objectName);
 }

--- a/src/main/java/ru/kpfu/itis/webapp/service/impl/FileServiceMinioImpl.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/impl/FileServiceMinioImpl.java
@@ -67,9 +67,9 @@ public class FileServiceMinioImpl implements FileService {
                             .object(objectName)
                             .build()
             );
-        } catch (MinioException | IOException e) {
-            log.error("Error deleting file: {}. Cause: {}", objectName, e.getMessage(), e);
-            throw new ServiceException("File deletion failed due to MinIO error: " + e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Error deleting file: {}", objectName, e);
+            throw new ServiceException("File deletion failed");
         }
     }
 

--- a/src/main/java/ru/kpfu/itis/webapp/service/impl/FileServiceMinioImpl.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/impl/FileServiceMinioImpl.java
@@ -2,6 +2,7 @@ package ru.kpfu.itis.webapp.service.impl;
 
 import io.minio.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.service.spi.ServiceException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,6 +56,21 @@ public class FileServiceMinioImpl implements FileService {
                         .build()
         );
         return getFileUrl(objectName);
+    }
+
+    @Override
+    public void deleteFile(String objectName) {
+        try {
+            minioClient.removeObject(
+                    RemoveObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(objectName)
+                            .build()
+            );
+        } catch (Exception e) {
+            log.error("Error deleting file: {}", objectName, e);
+            throw new ServiceException("File deletion failed");
+        }
     }
 
     @Override

--- a/src/main/java/ru/kpfu/itis/webapp/service/impl/FileServiceMinioImpl.java
+++ b/src/main/java/ru/kpfu/itis/webapp/service/impl/FileServiceMinioImpl.java
@@ -67,9 +67,9 @@ public class FileServiceMinioImpl implements FileService {
                             .object(objectName)
                             .build()
             );
-        } catch (Exception e) {
-            log.error("Error deleting file: {}", objectName, e);
-            throw new ServiceException("File deletion failed");
+        } catch (MinioException | IOException e) {
+            log.error("Error deleting file: {}. Cause: {}", objectName, e.getMessage(), e);
+            throw new ServiceException("File deletion failed due to MinIO error: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.sql.init.encoding=UTF-8
 spring.sql.init.data-locations=classpath:data.sql
 
 minio.endpoint=http://localhost:9000
-minio.accessKey=minio_access_key
-minio.secretKey=minio_secret_key
+minio.accessKey=minio_user
+minio.secretKey=minio_qwerty
 minio.bucket=event-horizon
 minio.init.enabled=false

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -100,7 +100,7 @@
             </ul>
             <ul class="navbar-nav">
                 <li class="nav-item">
-                    <a href="profile.html" class="nav-link fw-bold"><i class="fas fa-user-circle fa-lg" id="profile"></i> Личный кабинет</a>
+                    <a href="profile" class="nav-link fw-bold"><i class="fas fa-user-circle fa-lg" id="profile"></i> Личный кабинет</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Добавлен эндпоинт для удаления событий с полной очисткой связанных ресурсов

- Реализован DELETE /api/events/{eventId} для организаторов
- При удалении события:
  * Удаляются все связанные подписки (Participation)
  * Удаляются QR-коды подписок из хранилища MinIO
  * Удаляется изображение события из хранилища